### PR TITLE
bgzf/gzip/network file support added

### DIFF
--- a/source/swiftover/chain.d
+++ b/source/swiftover/chain.d
@@ -16,6 +16,7 @@ version(avl) import intevaltree.avltree;
 else import intervaltree.splaytree;
 
 import dhtslib.htslib.hts_log;
+import dhtslib.bgzf:BGZFile;
 
 import containers.hashmap;  // contig name -> size
 import containers.unrolledlist;
@@ -446,13 +447,10 @@ struct ChainFile
     /// Parse UCSC-format chain file into liftover trees (one tree per source contig)
     this(string fn)
     {
-        if (!fn.exists)
-            throw new FileException("File does not exist");
-
         this.qContigSizes = HashMap!(string,int)(256);
 
         // TODO: speed this pig up
-        auto chainArray = fn.File.byLineCopy().array();
+        auto chainArray = fn.BGZFile.array();
 
         long chainStart;
         long chainEnd;

--- a/source/swiftover/main.d
+++ b/source/swiftover/main.d
@@ -55,8 +55,8 @@ int main(string[] args)
     debug hts_set_log_level(htsLogLevel.HTS_LOG_DEBUG);
     debug(trace) hts_set_log_level(htsLogLevel.HTS_LOG_TRACE);
 
-    if (!chainfile.exists)
-        throw new FileException("Chainfile does not exist");
+    // if (!chainfile.exists)
+    //     throw new FileException("Chainfile does not exist");
     if (infile != "-" && infile != "" && !infile.exists)
         throw new FileException("Input file does not exist");
     // test write 


### PR DESCRIPTION
Only replaced a few lines. Had to comment out verifying that the chainfile exists to allow for network files. If you would like me to revert that change that I can, but it is necessary for the AWS lambda function / network files.